### PR TITLE
Adding nef file type to the list of mime types

### DIFF
--- a/src/mime.ml
+++ b/src/mime.ml
@@ -771,5 +771,6 @@ let map_filename_to_mime_type filename =
     | "movie" -> "video/x-sgi-movie"
     | "smv" -> "video/x-smv"
     | "ice" -> "x-conference/x-cooltalk"
+    | "nef" -> "image/x-nikon-nef"
     | _ -> "application/octet-stream"
 


### PR DESCRIPTION
Drive recognize nef files and can create thumbnails / view them in internal viewer but only if mime type is set properly. Adding proper mime type for them.
