### PR TITLE
Add gz format

### DIFF
--- a/src/mime.ml
+++ b/src/mime.ml
@@ -772,5 +772,6 @@ let map_filename_to_mime_type filename =
     | "smv" -> "video/x-smv"
     | "ice" -> "x-conference/x-cooltalk"
     | "nef" -> "image/x-nikon-nef"
+    | "gz" -> "application/x-gzip"
     | _ -> "application/octet-stream"
 


### PR DESCRIPTION
Google Drive started to reject all tar.gz files without proper MIME type
at Nov 20, which resulted in gdfuse silently creating empty files and
discarding their contents.