### PR TITLE
Remove unneeded escape_sql helper function

### DIFF
--- a/src/cache.ml
+++ b/src/cache.ml
@@ -2,10 +2,6 @@ open GapiUtils.Infix
 open GapiLens.Infix
 
 (* Helpers *)
-let escape_sql sql =
-  ExtString.String.replace_chars
-    (function '\'' -> "''" | c -> String.make 1 c) sql
-
 let fail rc =
   failwith ("Sqlite3 error: " ^ (Sqlite3.Rc.to_string rc))
 


### PR DESCRIPTION
This commit removes the escape_sql helper function. It doesn't seem to be needed anywhere (a grep over the codebase only yields the place of definition) and also it looks slightly dubious to me. (Is `'` really the only character which needs escaping?)

I appreciate your work! Thanks to google-drive-ocamlfuse, I was able to hack together [a short script](https://github.com/iblech/latex2png) which monitors a directory in Google Drive and extracts formulas as PNG images from LaTeX source files.