### PR TITLE
Allow macOS to open OAuth URL without headless

### DIFF
--- a/src/utils.ml
+++ b/src/utils.ml
@@ -121,7 +121,7 @@ let start_browser url =
       false
     end
   in
-  let browsers = ["xdg-open"; "firefox"; "google-chrome"] in
+  let browsers = ["xdg-open"; "firefox"; "google-chrome"; "open"] in
   let status =
     List.fold_left
       (fun result browser ->


### PR DESCRIPTION
`open` is available to macOS, all 3 original won't work on osx

terminal output for success call to `open`
```
9:46:57 › google-drive-ocamlfuse
/bin/sh: xdg-open: command not found
/bin/sh: firefox: command not found
/bin/sh: google-chrome: command not found
Access token retrieved correctly.
```