### PR TITLE
google-drive-ocamlfuse: unknown option '-m'.

### DIFF
--- a/src/gdfuse.ml
+++ b/src/gdfuse.ml
@@ -558,7 +558,7 @@ let () =
        "-d",
        Arg.Unit (fun _ -> fuse_args := "-d" :: !fuse_args),
        " enable FUSE debug output (implies -f).";
-       "-s",
+       "-m",
        Arg.Unit (fun _ ->
          multi_threading := true),
        " run in multi-threaded mode (default).";


### PR DESCRIPTION
I think -m makes more sense for 'multithreaded' than having two '-s' options ;)