### PR TITLE
Fix typos and broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ### FUSE filesystem for Google Drive
 
 `google-drive-ocamlfuse` is a FUSE-based file system backed by Google Drive, written in OCaml.
-It lets you mount your Google Drive on Linux. The project is hosted on [github](https://github.com/astrada/google-drive-ocamlfuse/),
-where you can find the latest development version. Project's documetation is hosted [here](https://github.com/astrada/google-drive-ocamlfuse/wiki).
+It lets you mount your Google Drive on Linux. The project is hosted on [GitHub](https://github.com/astrada/google-drive-ocamlfuse/),
+where you can find the latest development version. Project documentation is hosted [here](https://github.com/astrada/google-drive-ocamlfuse/wiki).
 There are Ubuntu packages in this [PPA](https://launchpad.net/~alessandro-strada/+archive/ubuntu/ppa).
 
 ### Features
@@ -18,5 +18,5 @@ There are Ubuntu packages in this [PPA](https://launchpad.net/~alessandro-strada
 * Unix permissions and ownership
 * Symbolic links
 * Read-ahead buffers when streaming
-* Accessing content shared with you (requires [configuration](doc/Configuration.md))
+* Accessing content shared with you (requires [configuration](https://github.com/astrada/google-drive-ocamlfuse/blob/beta/doc/Configuration.md))
 * Team Drive [Support](https://github.com/astrada/google-drive-ocamlfuse/wiki/Team-Drives)


### PR DESCRIPTION
Ciao Alessandro!

I found a typo and a broken link. The latter is probably related to a prior transition from the [`doc` folder](https://github.com/astrada/google-drive-ocamlfuse/tree/beta/doc) on the main branch.

The `doc` folder appears not to be used anymore. The documentation seems to have moved to the Wiki. We could move the content of this branch to the `doc` folder of the main branch (again) to clean up a bit. This would work with GitHub pages. What do you think?