### PR TITLE
Add support for NixOS using flakes with opam-nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  inputs = {
+    opam-nix.url = "github:tweag/opam-nix";
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.follows = "opam-nix/nixpkgs";
+  };
+  outputs = { self, flake-utils, opam-nix, nixpkgs }@inputs:
+    let package = "google-drive-ocamlfuse";
+    in flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        on = opam-nix.lib.${system};
+        scope =
+          on.buildOpamProject { } package ./. { ocaml-base-compiler = "*"; };
+        overlay = final: prev:
+          {
+          };
+      in {
+        legacyPackages = scope.overrideScope' overlay;
+
+        packages.default = self.legacyPackages.${system}.${package};
+      });
+}


### PR DESCRIPTION
An easy installation can be done, by modifying your configuration.nix as following (after the code is merged):

first, add flakes as experimental feature
```nix
{
  
  ...

  nix.settings.experimental-features = [
    "nix-command"
    "flakes"
  ];

  environment.systemPackages = with pkgs; [

    ...

    git
  ];
}
```

rebuild your system (`nixos-rebuild switch`)

then, add the google-drive-ocamlfuse flake
```nix
{
  environment.systemPackages = with pkgs; [

    ...

    (builtins.getFlake "github:astrada/google-drive-ocamlfuse").packages.x86_64-linux.default
  ];
}
```

I am by no means a NixOS expert. [opam-nix](https://github.com/tweag/opam-nix) generated  the flake file, making me do only basic configuration. I have tested the solution, though.

You can currently test it by changing
```diff
<    (builtins.getFlake "github:astrada/google-drive-ocamlfuse").packages.x86_64-linux.default
>    (builtins.getFlake "github:Surferlul/google-drive-ocamlfuse/nixos-flake").packages.x86_64-linux.default
```