### PR TITLE
Fixed typo in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
           {
           };
       in {
-        legacyPackages = scope.overrideScope' overlay;
+        legacyPackages = scope.overrideScope overlay;
 
         packages.default = self.legacyPackages.${system}.${package};
       });


### PR DESCRIPTION
Fixed a typo I originally introduced that caused the flake to be non-functional.