### PR TITLE
Add editable_docs config option for writable Google Docs

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -148,6 +148,9 @@ type t = {
   (* Specifies if transform desktop entries in HTML files, as support for
    * .desktop files is being removed from Nautilus. *)
   desktop_entry_as_html : bool;
+  (* Allow writing to exported Google Docs (e.g. HTML) and uploading changes
+   * back to Drive. Requires a convertible document_format such as html or docx. *)
+  editable_docs : bool;
   (* Async upload queue maximum number of entries (files) before blocking.
    * 0 means unlimited. *)
   async_upload_queue_max_length : int;
@@ -551,6 +554,12 @@ let desktop_entry_as_html =
     GapiLens.set = (fun v x -> { x with desktop_entry_as_html = v });
   }
 
+let editable_docs =
+  {
+    GapiLens.get = (fun x -> x.editable_docs);
+    GapiLens.set = (fun v x -> { x with editable_docs = v });
+  }
+
 let async_upload_queue_max_length =
   {
     GapiLens.get = (fun x -> x.async_upload_queue_max_length);
@@ -655,6 +664,7 @@ let default =
     scope = "";
     redirect_uri = "";
     desktop_entry_as_html = false;
+    editable_docs = false;
     async_upload_queue_max_length = 0;
     background_folder_fetching = false;
     oauth2_loopback = true;
@@ -728,6 +738,7 @@ let default_debug =
     scope = "";
     redirect_uri = "";
     desktop_entry_as_html = false;
+    editable_docs = false;
     async_upload_queue_max_length = 0;
     background_folder_fetching = false;
     oauth2_loopback = true;
@@ -843,6 +854,8 @@ let of_table table =
     redirect_uri = get "redirect_uri" Std.identity default.redirect_uri;
     desktop_entry_as_html =
       get "desktop_entry_as_html" bool_of_string default.desktop_entry_as_html;
+    editable_docs =
+      get "editable_docs" bool_of_string default.editable_docs;
     async_upload_queue_max_length =
       get "async_upload_queue_max_length" int_of_string
         default.async_upload_queue_max_length;
@@ -926,6 +939,7 @@ let to_table data =
   add "scope" data.scope;
   add "redirect_uri" data.redirect_uri;
   add "desktop_entry_as_html" (data.desktop_entry_as_html |> string_of_bool);
+  add "editable_docs" (data.editable_docs |> string_of_bool);
   add "async_upload_queue_max_length"
     (data.async_upload_queue_max_length |> string_of_int);
   add "background_folder_fetching"

--- a/src/config.mli
+++ b/src/config.mli
@@ -67,6 +67,7 @@ type t = {
   scope : string;
   redirect_uri : string;
   desktop_entry_as_html : bool;
+  editable_docs : bool;
   async_upload_queue_max_length : int;
   background_folder_fetching : bool;
   oauth2_loopback : bool;
@@ -137,6 +138,7 @@ val service_account_user_to_impersonate : (t, string) GapiLens.t
 val scope : (t, string) GapiLens.t
 val redirect_uri : (t, string) GapiLens.t
 val desktop_entry_as_html : (t, bool) GapiLens.t
+val editable_docs : (t, bool) GapiLens.t
 val async_upload_queue_max_length : (t, int) GapiLens.t
 val background_folder_fetching : (t, bool) GapiLens.t
 val oauth2_loopback : (t, bool) GapiLens.t

--- a/src/configStore.ml
+++ b/src/configStore.ml
@@ -57,6 +57,7 @@ let docs_table =
     "apps_script_icon";
     "desktop_entry_exec";
     "desktop_entry_as_html";
+    "editable_docs";
   ]
 
 let cache_table =
@@ -149,6 +150,7 @@ let bool_keys =
     "async_upload_queue";
     "debug_buffers";
     "desktop_entry_as_html";
+    "editable_docs";
     "background_folder_fetching";
     "oauth2_loopback";
   ]

--- a/src/drive.ml
+++ b/src/drive.ml
@@ -1713,7 +1713,10 @@ let is_filesystem_read_only () =
 let is_file_read_only resource =
   let config = Context.get_ctx () |. Context.config_lens in
   (not (Option.default true resource.CacheData.Resource.can_edit))
-  || CacheData.Resource.is_document resource
+  || (CacheData.Resource.is_document resource
+      && not
+           (config.Config.editable_docs
+           && CacheData.Resource.get_format resource config <> "desktop"))
   || config.Config.large_file_read_only
      && CacheData.Resource.is_large_file config resource
 
@@ -2245,7 +2248,11 @@ let upload resource =
   let content_path = Cache.get_content_path cache resource in
   let config = context |. Context.config_lens in
   let content_type =
-    if config.Config.autodetect_mime then ""
+    if CacheData.Resource.is_document resource && config.Config.editable_docs
+    then
+      let fmt = CacheData.Resource.get_format resource config in
+      CacheData.Resource.mime_type_of_format fmt
+    else if config.Config.autodetect_mime then ""
     else
       let file_source = GapiMediaResource.create_file_resource content_path in
       let resource_mime_type =


### PR DESCRIPTION
When editable_docs is true and document_format is a convertible format (e.g. html, docx), Google Docs become writable. Edits to the exported file are uploaded back to Drive, which converts them to native format and overwrites the original file.