### PR TITLE
Make statfs non-blocking by reading only cached metadata

### DIFF
--- a/src/drive.ml
+++ b/src/drive.ml
@@ -525,8 +525,32 @@ let drive_filesystem_stats_runtime metadata =
   let context = Context.get_ctx () in
   { DriveFilesystemStats.metadata; config = context |. Context.config_lens }
 
+(* Default metadata for statfs when no cached metadata is available yet (e.g.
+   right after mount, before the first refresh). storage_quota_limit = 0 makes
+   DriveFilesystemStats report unlimited space. *)
+let default_filesystem_stats_metadata =
+  {
+    CacheData.Metadata.display_name = "";
+    storage_quota_limit = 0L;
+    storage_quota_usage = 0L;
+    start_page_token = "";
+    cache_size = 0L;
+    last_update = 0.0;
+    clean_shutdown = false;
+  }
+
 let statfs () =
-  let metadata = get_metadata () in
+  (* Read ONLY the cached metadata; never trigger a network metadata refresh
+     here. statfs is invoked implicitly by df, GTK file choosers, GNOME's
+     disk-usage poll, some PAM stacks, etc. If it blocked on the network (or on
+     the metadata lock during a concurrent refresh) the calling process would
+     hang in uninterruptible D state, hanging those callers and breaking system
+     suspend (the freezer cannot freeze a D-state task). See issue #896. *)
+  let metadata =
+    match MetadataRefreshOps.get_cached_metadata () with
+    | Some metadata -> metadata
+    | None -> default_filesystem_stats_metadata
+  in
   DriveFilesystemStats.statfs (drive_filesystem_stats_runtime metadata)
 
 (* END Metadata *)

--- a/src/driveMetadataRefresh.ml
+++ b/src/driveMetadataRefresh.ml
@@ -315,6 +315,15 @@ module Make (P : PORTS) = struct
         Utils.log_with_header "BEGIN: Getting metadata from context\n%!";
         Some metadata
 
+  (* Non-blocking metadata accessor: returns the in-memory cached metadata (if
+     any) WITHOUT ever refreshing over the network or taking the metadata lock.
+     statfs must use this. A FUSE handler that blocks — on the network, or on
+     the metadata lock while a concurrent refresh holds it — keeps the *calling*
+     process in uninterruptible D state inside fuse_statfs/request_wait_answer.
+     That hangs df / ls / file choosers / some PAM stacks, and prevents the
+     kernel freezer from suspending the system. See issue #896. *)
+  let get_cached_metadata () = P.get_context_metadata ()
+
   let get_metadata runtime =
     P.with_metadata_lock (fun () ->
         match load_metadata runtime with

--- a/src/driveMetadataRefresh.mli
+++ b/src/driveMetadataRefresh.mli
@@ -66,4 +66,9 @@ end
 
 module Make (P : PORTS) : sig
   val get_metadata : runtime -> CacheData.Metadata.t
+
+  (* Returns the in-memory cached metadata without refreshing over the network
+     or taking the metadata lock. Used by statfs so it can never block (which
+     would hang df/ls and prevent system suspend — issue #896). *)
+  val get_cached_metadata : unit -> CacheData.Metadata.t option
 end


### PR DESCRIPTION
Fixes #896.

## Problem

`statfs` routes through `get_metadata`, which takes the metadata lock and performs a blocking, retrying network round-trip whenever the 60s metadata cache is stale. `statfs(2)` is invoked implicitly by `df`, GTK file choosers, GNOME's disk-usage poll, and some PAM stacks — so when Drive or the network stalls, those callers hang in uninterruptible D state inside the kernel FUSE layer (`fuse_statfs`/`request_wait_answer`). That is the hung `login`/`ssh`/`sudo`/`df` reported in #896, and it also breaks system suspend: the kernel freezer cannot freeze a D-state task, so every suspend attempt times out after 20s while the mount is stalled.

## Approach

Add `get_cached_metadata`, which returns the in-memory cached metadata **without** refreshing over the network and **without** taking the metadata lock (so a concurrent refresh holding the lock can't stall it either), and use it from `statfs`. Refreshing stays where it was — on the normal metadata paths; `statfs` just stops being able to trigger or wait on one.

Until the first refresh populates the cache (i.e. briefly after mount), `statfs` reports unlimited space via `storage_quota_limit = 0`, which `DriveFilesystemStats` already treats as "unlimited". Trade-off: `df` may show quota up to one refresh interval stale — strictly better than hanging.

## Testing

Running as a daily driver on Ubuntu 26.04 (libfuse3) since late June. With `-verbose` logging, 30 consecutive `statfs` calls add zero metadata-refresh log lines (previously each cache-stale call triggered one), and the suspend-blocking freezer failures stopped.
