### PR TITLE
Add Markdown export format for Google Docs

### DIFF
--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -79,6 +79,10 @@ formatting and metadata from the original Google document may be lost. It is
 safer to copy the file outside of the mounted drive, edit it there, and then
 copy it back, overwriting the original.
 
+For text documents, `document_format="md"` (Markdown) works well with
+`editable_docs`, because Markdown survives the Drive export/import round trip
+with less formatting noise than richer formats.
+
 Text document [[export format|Exportable-formats#valid-download-formats-for-text-documents]]:
 
     [docs]

--- a/docs/wiki/Exportable-formats.md
+++ b/docs/wiki/Exportable-formats.md
@@ -3,6 +3,7 @@
 * `docx` or `doc`: Microsoft Word
 * `epub`: Electronic Publication
 * `html` or `htm`: HTML Format
+* `md` or `markdown`: Markdown
 * `odt`: Open Document Format
 * `pdf`: Portable Document Format
 * `rtf`: Rich Text Format

--- a/docs/wiki/What's-new.md
+++ b/docs/wiki/What's-new.md
@@ -1,3 +1,10 @@
+0.9.1
+=====
+Google Docs can now be exported as Markdown by setting
+`document_format="md"` (or `"markdown"`). Combined with `editable_docs=true`,
+edits to the exported Markdown are converted back to the native Google Docs
+format on upload.
+
 0.9.0
 =====
 This version moves the filesystem to FUSE 3. Source builds now require

--- a/src/cacheData.ml
+++ b/src/cacheData.ml
@@ -412,6 +412,7 @@ module Resource = struct
     | "htm" | "html" -> "text/html"
     | "jpg" | "jpeg" -> "image/jpeg"
     | "json" -> "application/vnd.google-apps.script+json"
+    | "md" | "markdown" -> "text/markdown"
     | "ods" -> "application/x-vnd.oasis.opendocument.spreadsheet"
     | "odt" -> "application/vnd.oasis.opendocument.text"
     | "odp" -> "application/vnd.oasis.opendocument.presentation"

--- a/src/config.ml
+++ b/src/config.ml
@@ -149,7 +149,8 @@ type t = {
    * .desktop files is being removed from Nautilus. *)
   desktop_entry_as_html : bool;
   (* Allow writing to exported Google Docs (e.g. HTML) and uploading changes
-   * back to Drive. Requires a convertible document_format such as html or docx. *)
+   * back to Drive. Requires a convertible document_format such as html, md,
+   * or docx. *)
   editable_docs : bool;
   (* Async upload queue maximum number of entries (files) before blocking.
    * 0 means unlimited. *)

--- a/test/testDriveDownloads.ml
+++ b/test/testDriveDownloads.ml
@@ -332,6 +332,16 @@ let test_exportable_document_falls_back_to_export_call () =
           odt_mime_type)
        !FakePorts.trace)
 
+let test_markdown_document_exports_with_markdown_mime_type () =
+  FakePorts.reset ();
+  let config = document_config ~document_format:"md" () in
+  let resource = make_resource ~mime_type:document_mime_type "/doc" in
+  FakePorts.set_select [ Some resource ];
+  assert_equal content_path (download ~config resource);
+  assert_bool "expected markdown document export"
+    (List.mem "export_document:/cache/rid-file:rid-file:text/markdown"
+       !FakePorts.trace)
+
 let test_zero_byte_file_creates_empty_file () =
   FakePorts.reset ();
   let resource = make_resource ~size:0L "/empty.txt" in
@@ -402,6 +412,8 @@ let suite =
          >:: test_exportable_document_uses_cached_export_link;
          "test_exportable_document_falls_back_to_export_call"
          >:: test_exportable_document_falls_back_to_export_call;
+         "test_markdown_document_exports_with_markdown_mime_type"
+         >:: test_markdown_document_exports_with_markdown_mime_type;
          "test_zero_byte_file_creates_empty_file"
          >:: test_zero_byte_file_creates_empty_file;
          "test_media_failure_restores_to_download_before_handling_exception"

--- a/test/testDriveUploads.ml
+++ b/test/testDriveUploads.ml
@@ -221,6 +221,24 @@ let test_editable_document_uses_configured_format_without_preliminary_media () =
       let media = Option.get media_source in
       assert_equal expected_content_type media.GapiMediaResource.content_type)
 
+let test_editable_markdown_document_uploads_with_markdown_content_type () =
+  with_reset (fun () ->
+      let document_mime_type = "application/vnd.google-apps.document" in
+      let config =
+        {
+          Config.default with
+          editable_docs = true;
+          document_format = "md";
+          autodetect_mime = false;
+        }
+      in
+      let resource = make_resource ~mime_type:document_mime_type "/doc" in
+      FakePorts.set_media_lengths [ 42L ];
+      upload ~config resource;
+      let _file_id, media_source, _patch = last_remote_update () in
+      let media = Option.get media_source in
+      assert_equal "text/markdown" media.GapiMediaResource.content_type)
+
 let test_autodetect_mime_uses_empty_content_type () =
   with_reset (fun () ->
       let config = { Config.default with autodetect_mime = true } in
@@ -346,6 +364,8 @@ let suite =
   >::: [
          "test_editable_document_uses_configured_format_without_preliminary_media"
          >:: test_editable_document_uses_configured_format_without_preliminary_media;
+         "test_editable_markdown_document_uploads_with_markdown_content_type"
+         >:: test_editable_markdown_document_uploads_with_markdown_content_type;
          "test_autodetect_mime_uses_empty_content_type"
          >:: test_autodetect_mime_uses_empty_content_type;
          "test_cached_mime_preferred_when_autodetect_disabled"


### PR DESCRIPTION
Setting document_format to md (or markdown) exports Google Docs as text/markdown, a format the Drive API supports for both export and import. Combined with editable_docs, edits to the exported Markdown are converted back to the native Docs format on upload.